### PR TITLE
Set SameSite cookie attribute to 'Lax'

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -37,6 +37,7 @@ spring.security.oauth2.client.registration.facebook.scope[1]=public_profile
 
 server.servlet.session.timeout=1h
 server.servlet.session.cookie.max-age=1h
+server.servlet.session.cookie.same-site=LAX
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDB103Dialect
 spring.jpa.database-platform=org.hibernate.dialect.MariaDB103Dialect


### PR DESCRIPTION
Even though we have CSRF protection activated the attribute adds
another layer of protection, in line with the concept of
Defense in Depth.