### PR TITLE
FIX: Registration html5 verification: min value miscalculated

### DIFF
--- a/src/main/resources/static/js/register.js
+++ b/src/main/resources/static/js/register.js
@@ -5,13 +5,15 @@ const maxAge = 99;
 $(function() {
 
 	let today = new Date();
-	let startDate = new Date(today.setFullYear(today.getFullYear() - minAge)).toISOString().split('T')[0];
-	let endDate = new Date(today.setFullYear(today.getFullYear() - maxAge)).toISOString().split('T')[0];
+	let startDate = new Date(today.getTime());
+	startDate.setFullYear(today.getFullYear() - minAge)
+	let endDate = new Date(today.getTime());
+	endDate.setFullYear(today.getFullYear() - maxAge);
 
 	let dobInput = $("#dob-input");
 	//dobInput.val(startDate);
-	dobInput.attr('max', startDate);
-	dobInput.attr('min', endDate);
+	dobInput.attr('max', startDate.toISOString().split('T')[0]);
+	dobInput.attr('min', endDate.toISOString().split('T')[0]);
 
 	const queryString = window.location.search;
 	const urlParams = new URLSearchParams(queryString);


### PR DESCRIPTION
The today variable was changed by the calculation for the startDate /
max value, which changed the result of endDate.

fixes #157