### PR TITLE
Add openapi documentation with springdoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,16 @@
 			<artifactId>url-detector</artifactId>
 			<version>0.1.23</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-ui</artifactId>
+			<version>1.6.7</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-security</artifactId>
+			<version>1.6.7</version>
+		</dependency>
 
 	</dependencies>
 
@@ -223,6 +233,11 @@
 						</goals>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.springdoc</groupId>
+				<artifactId>springdoc-openapi-maven-plugin</artifactId>
+				<version>1.4</version>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
The UI can be found at https://localhost:8443/swagger-ui/index.html and the spec at https://localhost:8443/v3/api-docs