### PR TITLE
feat: add Dependabot to the repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
The idea is to use Github automatic security features and using it:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates
