### PR TITLE
ci: Add bugs to the Alovoa GitHub Project

### DIFF
--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -1,0 +1,19 @@
+name: Add bugs to the Alovoa GitHub Project
+
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    if: | 
+     github.event.pull_request.head.repo.full_name == github.repository ||
+     github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/Alovoa/projects/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          label-operator: AND


### PR DESCRIPTION
ci: Add bugs to the Alovoa GitHub Project

- [ ] Needs for a GitHub Project to be created https://github.com/Alovoa/alovoa/projects
- [ ] Needs a personal access token to work