### PR TITLE
fix: Open links in messages in new browser window

### DIFF
--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -453,13 +453,13 @@
     <div th:each="message : ${messages}" style="display: inline-block; width: 100%;">
 
         <div th:if="${message.from && message.allowedFormatting}" class="chat-message left"
-             th:utext='|<a href="${message.content}">${message.content}</a>|'></div>
+             th:utext='|<a href="${message.content}" target="_blank">${message.content}</a>|'></div>
         <div th:if="${message.from && !message.allowedFormatting}" class="chat-message left"
              th:text="${message.content}"></div>
 
         <div th:if="${!message.from  && message.allowedFormatting}"
              class="chat-message right notification is-primary"
-             th:utext='|<a href="${message.content}">${message.content}</a>|'></div>
+             th:utext='|<a href="${message.content}" target="_blank">${message.content}</a>|'></div>
         <div th:if="${!message.from  && !message.allowedFormatting}"
              class="chat-message right notification is-primary" th:text="${message.content}"></div>
 


### PR DESCRIPTION
When a video chat message is sent, the jit.si URL opens in the current browser window, thereby making it difficult for the (inexperienced) recipient to find their way back to the Alovoa chat. This PR adds a target="_blank" to the links in the message detail markup.