### PR TITLE
feat: Added option for ssl reverse proxy

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,6 +9,13 @@ server.port=${PORT:8080}
 #server.ssl.key-store-password=alovoa
 #server.ssl.key-alias=alovoa
 
+#enable the below for running behind an nginx SSL proxy
+#server.forward-headers-strategy=native
+#server.tomcat.remoteip.host-header=x-forwarded-for
+#server.tomcat.remoteip.port-header=x-forwarded-port
+#server.tomcat.remoteip.protocol-header=x-forwarded-proto
+#server.tomcat.remoteip.internal-proxies=.*
+
 spring.main.allow-bean-definition-overriding=true
 
 server.http2.enabled=true


### PR DESCRIPTION
This option is required when running an SSL reverse proxy in front of the application, in order to avoid erroneous redirects to localhost:8443

Added further properties that are necessary as per #288 