### PR TITLE
feat: captcha-configurable

### DIFF
--- a/src/main/java/com/nonononoki/alovoa/html/DeleteAccountResource.java
+++ b/src/main/java/com/nonononoki/alovoa/html/DeleteAccountResource.java
@@ -40,6 +40,9 @@ public class DeleteAccountResource {
     @Value("${app.user.delete.duration.valid}")
     private long accountDeleteDuration;
 
+    @Value("${app.captcha.delete.enabled}")
+    private String captchaDeleteEnabled;
+
     @GetMapping("/delete-account/{tokenString}")
     public ModelAndView deleteAccount(@PathVariable String tokenString) throws AlovoaException, InvalidKeyException,
             IllegalBlockSizeException, BadPaddingException, NoSuchAlgorithmException, NoSuchPaddingException,
@@ -57,6 +60,7 @@ public class DeleteAccountResource {
             active = true;
         }
         mav.addObject("active", active);
+        mav.addObject("captchaEnabled", Boolean.valueOf(captchaDeleteEnabled));
 
         return mav;
     }

--- a/src/main/java/com/nonononoki/alovoa/html/ImprintResource.java
+++ b/src/main/java/com/nonononoki/alovoa/html/ImprintResource.java
@@ -11,11 +11,16 @@ public class ImprintResource {
 	@Value("${app.company.name}")
 	private String companyName;
 
+	@Value("${app.captcha.enabled}")
+    private String captchaImprintEnabled;
+
 	@GetMapping("/imprint")
 	public ModelAndView imprint() {
 
 		ModelAndView mav = new ModelAndView("imprint");
 		mav.addObject("companyName", companyName);
+		mav.addObject("captchaEnabled", Boolean.valueOf(captchaImprintEnabled));
+
 		return mav;
 	}
 }

--- a/src/main/java/com/nonononoki/alovoa/html/LoginResource.java
+++ b/src/main/java/com/nonononoki/alovoa/html/LoginResource.java
@@ -18,7 +18,10 @@ public class LoginResource {
 
 	@Value("${app.privacy.update-date}")
 	private String privacyDate;
-	
+
+	@Value("${app.captcha.login.enabled}")
+	private String captchaEnabled;
+
 	public static final String URL = "/login";
 
 	@GetMapping(URL)
@@ -30,6 +33,7 @@ public class LoginResource {
 		}
 
 		ModelAndView mav = new ModelAndView("login");
+		mav.addObject("captchaEnabled", Boolean.valueOf(captchaEnabled));
 		return mav;
 	}
 }

--- a/src/main/java/com/nonononoki/alovoa/html/PasswordResource.java
+++ b/src/main/java/com/nonononoki/alovoa/html/PasswordResource.java
@@ -7,6 +7,7 @@ import com.nonononoki.alovoa.model.UserDto;
 import com.nonononoki.alovoa.service.AuthService;
 import com.nonononoki.alovoa.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,6 +35,9 @@ public class PasswordResource {
     @Autowired
     private TextEncryptorConverter textEncryptor;
 
+    @Value("${app.captcha.password.enabled}")
+    private String captchaPasswordEnabled;
+
     @GetMapping("/reset")
     public ModelAndView passwordReset() throws AlovoaException, InvalidKeyException, IllegalBlockSizeException,
             BadPaddingException, NoSuchAlgorithmException, NoSuchPaddingException, InvalidAlgorithmParameterException,
@@ -41,6 +45,7 @@ public class PasswordResource {
         ModelAndView mav = new ModelAndView("password-reset");
         User user = authService.getCurrentUser();
         mav.addObject("user", UserDto.userToUserDto(user, user, userService, textEncryptor, UserDto.NO_MEDIA));
+        mav.addObject("captchaEnabled", Boolean.valueOf(captchaPasswordEnabled));
         return mav;
     }
 

--- a/src/main/java/com/nonononoki/alovoa/html/RegisterResource.java
+++ b/src/main/java/com/nonononoki/alovoa/html/RegisterResource.java
@@ -1,6 +1,7 @@
 package com.nonononoki.alovoa.html;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,7 +28,7 @@ public class RegisterResource {
 
 	@Autowired
 	private AuthService authService;
-	
+
 	public static final String URL = "/register";
 
 	@GetMapping(URL)

--- a/src/main/java/com/nonononoki/alovoa/service/ImprintService.java
+++ b/src/main/java/com/nonononoki/alovoa/service/ImprintService.java
@@ -5,6 +5,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Date;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.nonononoki.alovoa.entity.Contact;
@@ -24,11 +25,16 @@ public class ImprintService {
 	@Autowired
 	private ContactRepository contactRepo;
 
+	@Value("${app.captcha.imprint.enabled}")
+	private String captchaImprintEnabled;
+
 	public Contact contact(ContactDto dto)
 			throws UnsupportedEncodingException, NoSuchAlgorithmException, AlovoaException {
-		boolean isValid = captchaService.isValid(dto.getCaptchaId(), dto.getCaptchaText());
-		if (!isValid) {
-			throw new AlovoaException(publicService.text("backend.error.captcha.invalid"));
+		if (Boolean.parseBoolean(captchaImprintEnabled)) {
+			boolean isValid = captchaService.isValid(dto.getCaptchaId(), dto.getCaptchaText());
+			if (!isValid) {
+				throw new AlovoaException(publicService.text("backend.error.captcha.invalid"));
+			}
 		}
 
 		Contact c = new Contact();

--- a/src/main/java/com/nonononoki/alovoa/service/PasswordService.java
+++ b/src/main/java/com/nonononoki/alovoa/service/PasswordService.java
@@ -52,14 +52,19 @@ public class PasswordService {
 	@Value("${app.user.password-reset.duration.valid}")
 	private int userPasswordResetDuration;
 
+	@Value("${app.captcha.password.enabled}")
+    private String captchaPasswordEnabled;
+
 	public UserPasswordToken resetPassword(PasswordResetDto dto)
 			throws AlovoaException, NoSuchAlgorithmException, MessagingException, IOException {
 
 		User u = authService.getCurrentUser();
 
 		if (u == null) {
-			if (!captchaService.isValid(dto.getCaptchaId(), dto.getCaptchaText())) {
-				throw new AlovoaException("captcha_invalid");
+			if (Boolean.parseBoolean(captchaPasswordEnabled)) {
+				if (!captchaService.isValid(dto.getCaptchaId(), dto.getCaptchaText())) {
+					throw new AlovoaException("captcha_invalid");
+				}
 			}
 			u = userRepo.findByEmail(Tools.cleanEmail(dto.getEmail()));
 

--- a/src/main/java/com/nonononoki/alovoa/service/UserService.java
+++ b/src/main/java/com/nonononoki/alovoa/service/UserService.java
@@ -120,6 +120,9 @@ public class UserService {
     @Value("${app.intention.delay}")
     private long intentionDelay;
 
+    @Value("${app.captcha.delete.enabled}")
+    private String captchaDeleteEnabled;
+
     public static void removeUserDataCascading(User user, UserDeleteParams userDeleteParam) {
 
         UserRepository userRepo = userDeleteParam.getUserRepo();
@@ -329,8 +332,10 @@ public class UserService {
             throw new AlovoaException("deletion_wrong_email");
         }
 
-        if (!captchaService.isValid(dto.getCaptchaId(), dto.getCaptchaText())) {
-            throw new AlovoaException("captcha_invalid");
+        if (Boolean.parseBoolean(captchaDeleteEnabled)) {
+            if (!captchaService.isValid(dto.getCaptchaId(), dto.getCaptchaText())) {
+                throw new AlovoaException("captcha_invalid");
+            }
         }
 
         UserDeleteParams userDeleteParam = UserDeleteParams.builder().conversationRepo(conversationRepo)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,11 @@ spring.profiles.active=test
 
 server.port=${PORT:8080}
 
+app.captcha.login.enabled=false
+app.captcha.delete.enabled=false
+app.captcha.imprint.enabled=true
+app.captcha.password.enabled=false
+
 #enable to force https for development
 #server.ssl.key-store-type=PKCS12
 #server.ssl.key-store=alovoa.p12

--- a/src/main/resources/templates/delete-account.html
+++ b/src/main/resources/templates/delete-account.html
@@ -38,7 +38,9 @@
                         <input class="input" name="email" required th:placeholder="#{email}" type="email">
                     </div>
                     <div style="padding-top: 32px;"></div>
-                    <div th:replace="~{fragments.html::captcha}"></div>
+                    <div th:if="${captchaEnabled}">
+                        <div th:replace="~{fragments.html::captcha}"></div>
+                    </div>
                     <div class="field">
                         <input class="switch" id="confirm" name="confirm" required style="position: absolute"
                                type="checkbox"> <label for="confirm"><span th:text="#{delete-account.confirm}"></span>

--- a/src/main/resources/templates/imprint.html
+++ b/src/main/resources/templates/imprint.html
@@ -48,7 +48,9 @@
 									th:placeholder="#{message}" required></textarea>
 							</div>
 							<div style="padding-top: 12px;"></div>
-							<div th:replace="~{fragments.html::captcha}"></div>
+							<div th:if="${captchaEnabled}">
+								<div th:replace="~{fragments.html::captcha}"></div>
+							</div>
 							<button class="button colored is-primary" th:text="#{submit}"></button>
 						</form>
 					</div>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -60,7 +60,9 @@
 												name="password">
 										</div>
 									</div>
-									<div th:replace="~{fragments.html::captcha}"></div>
+									<div th:if="${captchaEnabled}">
+										<div th:replace="~{fragments.html::captcha}"></div>
+									</div>
 									<div class="field">
 										<label class="checkbox"> <input type="checkbox" name="remember-me" checked> <span
 												th:text="#{login.remember}"></span>

--- a/src/main/resources/templates/password-reset.html
+++ b/src/main/resources/templates/password-reset.html
@@ -31,7 +31,9 @@
 									<input class="input" type="email" autofocus="" name="email" id="email" required>
 								</div>
 							</div>
-							<div th:replace="~{fragments.html::captcha}"></div>
+							<div th:if="${captchaEnabled}">
+								<div th:replace="~{fragments.html::captcha}"></div>
+							</div>
 							<button class="button is-info colored" th:text="#{submit}"></button>
 						</form>
 					</div>


### PR DESCRIPTION
Make captcha configurable in *application.properties*:

```
app.captcha.login.enabled=false
app.captcha.delete.enabled=false
app.captcha.imprint.enabled=true
app.captcha.password.enabled=false
```

In original code captcha is not implemented for registration, so it is not implemented in that pull request also. An issue may be OAuth2 registrations, if captcha is required on registration.
